### PR TITLE
トップページの商品一覧のデータ取得方法を修正

### DIFF
--- a/app/controllers/toppages_controller.rb
+++ b/app/controllers/toppages_controller.rb
@@ -3,10 +3,9 @@ class ToppagesController < ApplicationController
   before_action :get_categories, only:[:index]
   
   def index
-    # @category = Category.all.order("id ASC").limit(13)
-    @item = Item.all.order("id DESC").first(6)
-    # .where.not(current_user.id == seller.id)
-    @image = Image.all.order("id DESC")
+    @items = Item.includes(:images).order("id DESC").first(6)
+    # includesでitemモデルの子モデル(imageモデル)を取得できる
+    # 一対多なので「images」複数形になっている
   end
 
 end

--- a/app/views/toppages/_toppage_middle.html.haml
+++ b/app/views/toppages/_toppage_middle.html.haml
@@ -95,13 +95,13 @@
       .pcContent-contentInner_items-contents 
         %p.new-items 新規投稿商品
       .pcContent-contentInner_items-lists
-        - @item.zip(@image) do |o,i|
-          %ul
-            %li
-              = link_to item_path(o.id) do
-                = image_tag i.image.url, class:"pro_pic"
-            %li.pro_name
-              = o.name
+        - @items.each do |item|
+          = link_to item_path(item.id) do
+            %ul
+              %li
+                = image_tag item.images[0].image.url, class:"pro_pic"
+              %li.pro_name
+                = item.name
   .pcContent-contentInner_image3_footer_image3
     .pcContent-contentInner_image3_footer_image3_main3
       = image_tag "bg-appBanner-pict.jpg", class:"main3", alt:"ほげ"


### PR DESCRIPTION
# what
商品一覧の取り出し方を修正
toppageのビューとtoppagesコントローラーの記述を修正

# why
- より無駄なくデータを取り出す為
- 商品一覧の画像が商品詳細の画像と食い違いがあったので修正